### PR TITLE
add dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/auth_server"
+    schedule:
+      interval: "daily"
+    allow:
+      - dependency-type: "all"


### PR DESCRIPTION
This enables dependabot for the go.mod in the directory auth_server.